### PR TITLE
fix(moynalog): retry sending receipt with re-authentication on failure

### DIFF
--- a/internal/payment/payment.go
+++ b/internal/payment/payment.go
@@ -484,7 +484,25 @@ func (s PaymentService) sendReceiptToMoynalog(purchase *database.Purchase) error
 	// Вызов метода для создания чека
 	_, err := s.moynalogClient.CreateIncome(amount, comment)
 	if err != nil {
-		return fmt.Errorf("failed to create income in Moynalog: %w", err)
+		slog.Warn("first attempt to send receipt to Moynalog failed, retrying with re-authentication", "error", err, "purchase_id", utils.MaskHalfInt64(purchase.ID))
+
+		// Повторная аутентификация
+		newClient, authErr := moynalog.NewClient(config.MoynalogUrl(), config.MoynalogUsername(), config.MoynalogPassword())
+		if authErr != nil {
+			return fmt.Errorf("authentication failed after error: %w", authErr)
+		}
+
+		// Обновляем клиент в сервисе
+		s.moynalogClient = newClient
+
+		// Повторная попытка отправки чека
+		_, retryErr := s.moynalogClient.CreateIncome(amount, comment)
+		if retryErr != nil {
+			return fmt.Errorf("failed to create income in Moynalog after re-authentication: %w", retryErr)
+		}
+
+		slog.Info("Receipt successfully sent to Moynalog after re-authentication", "purchase_id", utils.MaskHalfInt64(purchase.ID))
+		return nil
 	}
 
 	slog.Info("Receipt sent to Moynalog", "purchase_id", utils.MaskHalfInt64(purchase.ID), "amount", amount, "comment", comment)


### PR DESCRIPTION
Первоначальная попытка отправки чека в «Мой Налог» могла завершаться неудачей по различным причинам, включая истечение срока действия токена аутентификации. В таком случае вся операция прерывалась без попытки восстановления.

В данном изменении добавлен механизм повторной попытки. Если первый вызов API для создания дохода завершается ошибкой, сервис повторно проходит аутентификацию, получает новый клиент и выполняет запрос ещё раз. Это повышает устойчивость и надёжность процесса отправки чеков.

P.S. Не ясно, по какой причине данная логика отсутствовала или была утрачена в предыдущей реализации.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of payment receipt delivery by adding automatic retry functionality when initial transmission encounters failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->