### PR TITLE
feat: payload structure changed to accommodate the new tribute webhooks

### DIFF
--- a/internal/tribute/models.go
+++ b/internal/tribute/models.go
@@ -17,7 +17,7 @@ type Payload struct {
 	Price            int       `json:"price"`
 	Amount           int       `json:"amount"`
 	Currency         string    `json:"currency"`
-	UserID           int       `json:"user_id"`
+	UserID           string    `json:"trb_user_id"`
 	TelegramUserID   int64     `json:"telegram_user_id"`
 	ChannelID        int       `json:"channel_id"`
 	ChannelName      string    `json:"channel_name"`


### PR DESCRIPTION
Closes `#65`

- update Tribute payload field: `user_id` -> `trb_user_id`
- change `UserID` type from `int` to `string`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected user identifier field format and naming in webhook payloads to ensure accurate data handling and proper integration compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->