### PR TITLE
feat(menu): persistent photos and pinned start navigation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,6 +9,11 @@ STARS_PRICE_12=123123
 
 TELEGRAM_TOKEN=token
 
+# Optional JPEG/PNG for /start and inline sections. Empty = text-only menus.
+# Docker: put the file in ./assets and set MENU_PHOTO_PATH=/assets/menu.jpg.
+# Telegram file_id and start pins are stored in PostgreSQL across restarts.
+MENU_PHOTO_PATH=
+
 REFERRAL_DAYS=7
 
 MINI_APP_URL=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2026-09-06
+
+### Added
+- Optional local menu photo configured with `MENU_PHOTO_PATH`, cached by content and bot identity in PostgreSQL and reused across restarts.
+- Persistent tracking of start-message pins: each `/start` pins the new menu before unpinning previous bot menus, with retryable cleanup.
+
+### Fixed
+- Inline section navigation now edits photo captions without removing the image or changing the message ID. Legacy text menus remain supported.
+- Payment completion preserves the menu and its pin instead of deleting the message.
+
+### Tests
+- Added photo cache, restart/replacement, concurrent request, Telegram error, pin lifecycle, caption navigation and payment-menu regressions.
+
 ## [5.0.1] - 2026-08-31
 
 ### Fixed

--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -14,6 +14,7 @@ import (
 	"remnawave-tg-shop-bot/internal/cryptopay"
 	"remnawave-tg-shop-bot/internal/database"
 	"remnawave-tg-shop-bot/internal/handler"
+	"remnawave-tg-shop-bot/internal/menu"
 	"remnawave-tg-shop-bot/internal/moynalog"
 	"remnawave-tg-shop-bot/internal/notification"
 	"remnawave-tg-shop-bot/internal/payment"
@@ -116,7 +117,11 @@ func main() {
 
 	syncService := sync.NewSyncService(remnawaveClient, customerRepository)
 
-	h := handler.NewHandler(syncService, paymentService, tm, customerRepository, purchaseRepository, cryptoPayClient, yookasaClient, referralRepository, cache)
+	menuService, err := menu.New(ctx, database.NewMenuRepository(pool), b.ID(), config.MenuPhotoPath())
+	if err != nil {
+		panic(fmt.Errorf("initialize menu: %w", err))
+	}
+	h := handler.NewHandler(syncService, paymentService, tm, customerRepository, purchaseRepository, cryptoPayClient, yookasaClient, referralRepository, cache, menuService)
 
 	me, err := b.GetMe(ctx)
 	if err != nil {

--- a/db/migrations/000006_add_menu_state.down.sql
+++ b/db/migrations/000006_add_menu_state.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS bot_menu_pin;
+DROP TABLE IF EXISTS bot_menu_photo;

--- a/db/migrations/000006_add_menu_state.up.sql
+++ b/db/migrations/000006_add_menu_state.up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE bot_menu_photo (
+    bot_id BIGINT NOT NULL,
+    path TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    file_id TEXT NOT NULL,
+    PRIMARY KEY (bot_id, path)
+);
+
+-- Only this bot's menu pins are tracked; unrelated chat pins are never removed.
+-- Retaining pending cleanup rows makes unpin failures retryable after restart.
+CREATE TABLE bot_menu_pin (
+    bot_id BIGINT NOT NULL,
+    chat_id BIGINT NOT NULL,
+    message_id INTEGER NOT NULL CHECK (message_id > 0),
+    PRIMARY KEY (bot_id, chat_id, message_id)
+);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
         condition: service_healthy
     volumes:
       - ./translations:/translations
+      - ./assets:/assets:ro
 
   db:
     image: postgres:17

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 type config struct {
+	menuPhotoPath                                             string
 	telegramToken                                             string
 	price1, price3, price6, price12                           int
 	starsPrice1, starsPrice3, starsPrice6, starsPrice12       int
@@ -61,6 +62,10 @@ type config struct {
 }
 
 var conf config
+
+func MenuPhotoPath() string {
+	return conf.menuPhotoPath
+}
 
 func RemnawaveTag() string {
 	return conf.remnawaveTag
@@ -407,6 +412,7 @@ func InitConfig() {
 	}
 
 	conf.telegramToken = mustEnv("TELEGRAM_TOKEN")
+	conf.menuPhotoPath = strings.TrimSpace(os.Getenv("MENU_PHOTO_PATH"))
 
 	conf.isWebAppLinkEnabled = func() bool {
 		isWebAppLinkEnabled := os.Getenv("IS_WEB_APP_LINK") == "true"

--- a/internal/database/menu.go
+++ b/internal/database/menu.go
@@ -1,0 +1,63 @@
+package database
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"remnawave-tg-shop-bot/internal/menu"
+)
+
+type MenuRepository struct {
+	pool *pgxpool.Pool
+}
+
+var _ menu.Store = (*MenuRepository)(nil)
+
+func NewMenuRepository(pool *pgxpool.Pool) *MenuRepository {
+	return &MenuRepository{pool: pool}
+}
+
+func (r *MenuRepository) LoadPhoto(ctx context.Context, botID int64, path string) (menu.PhotoRecord, error) {
+	var photo menu.PhotoRecord
+	err := r.pool.QueryRow(ctx, "SELECT content_hash, file_id FROM bot_menu_photo WHERE bot_id = $1 AND path = $2", botID, path).Scan(&photo.Hash, &photo.FileID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return photo, nil
+	}
+	return photo, err
+}
+
+func (r *MenuRepository) SavePhoto(ctx context.Context, botID int64, path string, photo menu.PhotoRecord) error {
+	_, err := r.pool.Exec(ctx, `INSERT INTO bot_menu_photo (bot_id, path, content_hash, file_id) VALUES ($1, $2, $3, $4)
+		ON CONFLICT (bot_id, path) DO UPDATE SET content_hash = EXCLUDED.content_hash, file_id = EXCLUDED.file_id`,
+		botID, path, photo.Hash, photo.FileID)
+	return err
+}
+
+func (r *MenuRepository) ListPins(ctx context.Context, botID, chatID int64) ([]int, error) {
+	rows, err := r.pool.Query(ctx, "SELECT message_id FROM bot_menu_pin WHERE bot_id = $1 AND chat_id = $2 ORDER BY message_id", botID, chatID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (r *MenuRepository) TrackPin(ctx context.Context, botID, chatID int64, messageID int) error {
+	_, err := r.pool.Exec(ctx, "INSERT INTO bot_menu_pin (bot_id, chat_id, message_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING", botID, chatID, messageID)
+	return err
+}
+
+func (r *MenuRepository) ForgetPin(ctx context.Context, botID, chatID int64, messageID int) error {
+	_, err := r.pool.Exec(ctx, "DELETE FROM bot_menu_pin WHERE bot_id = $1 AND chat_id = $2 AND message_id = $3", botID, chatID, messageID)
+	return err
+}

--- a/internal/handler/connect.go
+++ b/internal/handler/connect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"remnawave-tg-shop-bot/internal/config"
+	"remnawave-tg-shop-bot/internal/menu"
 	"strings"
 	"time"
 
@@ -40,18 +41,8 @@ func (h Handler) ConnectCommandHandler(ctx context.Context, b *bot.Bot, update *
 	}
 	markup = append(markup, []models.InlineKeyboardButton{h.translation.GetButton(langCode, "back_button").InlineCallback(CallbackStart)})
 
-	isDisabled := true
-	_, err = b.SendMessage(ctx, &bot.SendMessageParams{
-		ChatID:    update.Message.Chat.ID,
-		Text:      buildConnectText(customer, langCode),
-		ParseMode: models.ParseModeHTML,
-		LinkPreviewOptions: &models.LinkPreviewOptions{
-			IsDisabled: &isDisabled,
-		},
-		ReplyMarkup: models.InlineKeyboardMarkup{
-			InlineKeyboard: markup,
-		},
-	})
+	_, err = h.menu.Send(ctx, b, update.Message.Chat.ID, buildConnectText(customer, langCode),
+		models.InlineKeyboardMarkup{InlineKeyboard: markup})
 
 	if err != nil {
 		slog.Error("Error sending connect message", "error", err)
@@ -85,7 +76,7 @@ func (h Handler) ConnectCallbackHandler(ctx context.Context, b *bot.Bot, update 
 	markup = append(markup, []models.InlineKeyboardButton{h.translation.GetButton(langCode, "back_button").InlineCallback(CallbackStart)})
 
 	isDisabled := true
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	_, err = menu.Edit(ctx, b, callback, &bot.EditMessageTextParams{
 		ChatID:    callback.Chat.ID,
 		MessageID: callback.ID,
 		ParseMode: models.ParseModeHTML,

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -4,6 +4,7 @@ import (
 	"remnawave-tg-shop-bot/internal/cache"
 	"remnawave-tg-shop-bot/internal/cryptopay"
 	"remnawave-tg-shop-bot/internal/database"
+	"remnawave-tg-shop-bot/internal/menu"
 	"remnawave-tg-shop-bot/internal/payment"
 	"remnawave-tg-shop-bot/internal/sync"
 	"remnawave-tg-shop-bot/internal/translation"
@@ -11,6 +12,7 @@ import (
 )
 
 type Handler struct {
+	menu               *menu.Service
 	customerRepository *database.CustomerRepository
 	purchaseRepository *database.PurchaseRepository
 	cryptoPayClient    *cryptopay.Client
@@ -29,8 +31,9 @@ func NewHandler(
 	customerRepository *database.CustomerRepository,
 	purchaseRepository *database.PurchaseRepository,
 	cryptoPayClient *cryptopay.Client,
-	yookasaClient *yookasa.Client, referralRepository *database.ReferralRepository, cache *cache.Cache) *Handler {
+	yookasaClient *yookasa.Client, referralRepository *database.ReferralRepository, cache *cache.Cache, menuService *menu.Service) *Handler {
 	return &Handler{
+		menu:               menuService,
 		syncService:        syncService,
 		paymentService:     paymentService,
 		customerRepository: customerRepository,

--- a/internal/handler/menu_test.go
+++ b/internal/handler/menu_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"remnawave-tg-shop-bot/internal/translation"
+)
+
+func TestBuyCallbackEditsCaptionForPhoto(t *testing.T) {
+	for _, photo := range []bool{false, true} {
+		method := "editMessageText"
+		if photo {
+			method = "editMessageCaption"
+		}
+		t.Run(method, func(t *testing.T) {
+			requests := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := r.ParseMultipartForm(1 << 20); err != nil {
+					t.Error(err)
+					return
+				}
+				defer r.MultipartForm.RemoveAll()
+				requests <- r.URL.Path
+				if r.FormValue("message_id") != "99" || !strings.Contains(r.FormValue("reply_markup"), "start") {
+					t.Error("lost menu navigation")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("{\"ok\":true,\"result\":{\"message_id\":99}}"))
+			}))
+			defer server.Close()
+			b, err := bot.New("123:test", bot.WithSkipGetMe(), bot.WithServerURL(server.URL))
+			if err != nil {
+				t.Fatal(err)
+			}
+			msg := &models.Message{ID: 99, Chat: models.Chat{ID: 42}}
+			if photo {
+				msg.Photo = []models.PhotoSize{{FileID: "keep-photo"}}
+			}
+			h := Handler{translation: translation.GetInstance()}
+			h.BuyCallbackHandler(context.Background(), b, &models.Update{CallbackQuery: &models.CallbackQuery{
+				From: models.User{ID: 42, LanguageCode: "en"}, Message: models.MaybeInaccessibleMessage{Message: msg},
+			}})
+			if path := <-requests; !strings.HasSuffix(path, "/"+method) {
+				t.Fatalf("wrong API method: %s", path)
+			}
+		})
+	}
+}

--- a/internal/handler/payment_handlers.go
+++ b/internal/handler/payment_handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"remnawave-tg-shop-bot/internal/config"
 	"remnawave-tg-shop-bot/internal/database"
+	"remnawave-tg-shop-bot/internal/menu"
 	"remnawave-tg-shop-bot/internal/remnawave"
 )
 
@@ -51,7 +52,7 @@ func (h Handler) BuyCallbackHandler(ctx context.Context, b *bot.Bot, update *mod
 		h.translation.GetButton(langCode, "back_button").InlineCallback(CallbackStart),
 	})
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	_, err := menu.Edit(ctx, b, callback, &bot.EditMessageTextParams{
 		ChatID:    callback.Chat.ID,
 		MessageID: callback.ID,
 		ParseMode: models.ParseModeHTML,

--- a/internal/handler/referral.go
+++ b/internal/handler/referral.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"remnawave-tg-shop-bot/internal/menu"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
@@ -30,7 +31,7 @@ func (h Handler) ReferralCallbackHandler(ctx context.Context, b *bot.Bot, update
 	}
 	text := fmt.Sprintf(h.translation.GetText(langCode, "referral_text"), count)
 	callbackMessage := update.CallbackQuery.Message.Message
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	_, err = menu.Edit(ctx, b, callbackMessage, &bot.EditMessageTextParams{
 		ChatID:    callbackMessage.Chat.ID,
 		MessageID: callbackMessage.ID,
 		Text:      text,

--- a/internal/handler/start.go
+++ b/internal/handler/start.go
@@ -12,6 +12,7 @@ import (
 
 	"remnawave-tg-shop-bot/internal/config"
 	"remnawave-tg-shop-bot/internal/database"
+	"remnawave-tg-shop-bot/internal/menu"
 	"remnawave-tg-shop-bot/utils"
 )
 
@@ -92,14 +93,8 @@ func (h Handler) StartCommandHandler(ctx context.Context, b *bot.Bot, update *mo
 		return
 	}
 
-	_, err = b.SendMessage(ctx, &bot.SendMessageParams{
-		ChatID:    update.Message.Chat.ID,
-		ParseMode: models.ParseModeHTML,
-		ReplyMarkup: models.InlineKeyboardMarkup{
-			InlineKeyboard: inlineKeyboard,
-		},
-		Text: h.translation.GetText(langCode, "greeting"),
-	})
+	_, err = h.menu.SendStart(ctx, b, update.Message.Chat.ID, h.translation.GetText(langCode, "greeting"),
+		models.InlineKeyboardMarkup{InlineKeyboard: inlineKeyboard})
 	if err != nil {
 		slog.Error("Error sending /start message", "error", err)
 	}
@@ -120,7 +115,7 @@ func (h Handler) StartCallbackHandler(ctx context.Context, b *bot.Bot, update *m
 
 	inlineKeyboard := h.buildStartKeyboard(existingCustomer, langCode)
 
-	_, err = b.EditMessageText(ctxWithTime, &bot.EditMessageTextParams{
+	_, err = menu.Edit(ctxWithTime, b, callback.Message.Message, &bot.EditMessageTextParams{
 		ChatID:    callback.Message.Message.Chat.ID,
 		MessageID: callback.Message.Message.ID,
 		ParseMode: models.ParseModeHTML,

--- a/internal/handler/trial.go
+++ b/internal/handler/trial.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	"remnawave-tg-shop-bot/internal/config"
+	"remnawave-tg-shop-bot/internal/menu"
 	"remnawave-tg-shop-bot/internal/remnawave"
 	"remnawave-tg-shop-bot/utils"
 )
@@ -30,7 +31,7 @@ func (h Handler) TrialCallbackHandler(ctx context.Context, b *bot.Bot, update *m
 	}
 	callback := update.CallbackQuery.Message.Message
 	langCode := update.CallbackQuery.From.LanguageCode
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	_, err = menu.Edit(ctx, b, callback, &bot.EditMessageTextParams{
 		ChatID:    callback.Chat.ID,
 		MessageID: callback.ID,
 		Text:      h.translation.GetText(langCode, "trial_text"),
@@ -69,7 +70,7 @@ func (h Handler) ActivateTrialCallbackHandler(ctx context.Context, b *bot.Bot, u
 		return
 	}
 	langCode := update.CallbackQuery.From.LanguageCode
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	_, err = menu.Edit(ctx, b, callback, &bot.EditMessageTextParams{
 		ChatID:      callback.Chat.ID,
 		MessageID:   callback.ID,
 		Text:        h.translation.GetText(langCode, "trial_activated"),

--- a/internal/menu/menu.go
+++ b/internal/menu/menu.go
@@ -1,0 +1,249 @@
+// Package menu keeps navigation on one message, with an optional cached photo.
+package menu
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+)
+
+// PhotoRecord is scoped to both the bot and the configured file path.
+type PhotoRecord struct {
+	Hash   string
+	FileID string
+}
+
+type Store interface {
+	LoadPhoto(context.Context, int64, string) (PhotoRecord, error)
+	SavePhoto(context.Context, int64, string, PhotoRecord) error
+	ListPins(context.Context, int64, int64) ([]int, error)
+	TrackPin(context.Context, int64, int64, int) error
+	ForgetPin(context.Context, int64, int64, int) error
+}
+
+type Service struct {
+	store      Store
+	botID      int64
+	path       string
+	data       []byte
+	digest     string
+	photoMu    sync.Mutex
+	fileID     string
+	photoDirty bool
+	// Bounded locks serialize concurrent /start requests in the same chat.
+	chatLocks [64]sync.Mutex
+}
+
+// New loads the source once. Replacing the file takes effect after a restart.
+// If the file is temporarily absent, a persisted Telegram file_id still works.
+func New(ctx context.Context, store Store, botID int64, path string) (*Service, error) {
+	s := &Service{store: store, botID: botID, path: path}
+	if path == "" {
+		return s, nil
+	}
+	s.path = filepath.Clean(path)
+	record, err := store.LoadPhoto(ctx, botID, s.path)
+	if err != nil {
+		return nil, fmt.Errorf("load menu photo cache: %w", err)
+	}
+	f, err := os.Open(s.path)
+	if errors.Is(err, os.ErrNotExist) && record.FileID != "" {
+		s.fileID, s.digest = record.FileID, record.Hash
+		slog.Warn("Menu photo source missing; using cached Telegram file", "path", s.path)
+		return s, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("open menu photo: %w", err)
+	}
+	defer f.Close()
+	const maxPhotoSize = 10 * 1024 * 1024
+	s.data, err = io.ReadAll(io.LimitReader(f, maxPhotoSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read menu photo: %w", err)
+	}
+	if len(s.data) > maxPhotoSize {
+		return nil, errors.New("menu photo must be at most 10 MB")
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(s.data))
+	if err != nil {
+		return nil, fmt.Errorf("menu photo must be a valid JPEG or PNG: %w", err)
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 || cfg.Width+cfg.Height > 10000 ||
+		float64(cfg.Width)/float64(cfg.Height) > 20 || float64(cfg.Height)/float64(cfg.Width) > 20 {
+		return nil, errors.New("menu photo dimensions exceed Telegram limits (width + height <= 10000, aspect ratio <= 20)")
+	}
+	s.digest = fmt.Sprintf("%x", sha256.Sum256(s.data))
+	if record.Hash == s.digest {
+		s.fileID = record.FileID
+	}
+	return s, nil
+}
+
+func (s *Service) Send(ctx context.Context, b *bot.Bot, chatID int64, text string, keyboard models.ReplyMarkup) (*models.Message, error) {
+	if s.path == "" {
+		disabled := true
+		return b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID, Text: text, ParseMode: models.ParseModeHTML, ReplyMarkup: keyboard,
+			LinkPreviewOptions: &models.LinkPreviewOptions{IsDisabled: &disabled},
+		})
+	}
+	s.photoMu.Lock()
+	if s.photoDirty {
+		s.persistPhoto(ctx)
+	}
+	fileID := s.fileID
+	if fileID == "" {
+		defer s.photoMu.Unlock()
+		return s.upload(ctx, b, chatID, text, keyboard)
+	}
+	s.photoMu.Unlock()
+	message, err := b.SendPhoto(ctx, &bot.SendPhotoParams{
+		ChatID: chatID, Photo: &models.InputFileString{Data: fileID},
+		Caption: text, ParseMode: models.ParseModeHTML, ReplyMarkup: keyboard,
+	})
+	if !invalidFileID(err) {
+		return message, err
+	}
+	// Retry only a rejected file_id, never timeouts or arbitrary 400 errors:
+	// those may have delivered the message or indicate an invalid caption.
+	s.photoMu.Lock()
+	defer s.photoMu.Unlock()
+	if s.fileID != fileID && s.fileID != "" {
+		return b.SendPhoto(ctx, &bot.SendPhotoParams{
+			ChatID: chatID, Photo: &models.InputFileString{Data: s.fileID},
+			Caption: text, ParseMode: models.ParseModeHTML, ReplyMarkup: keyboard,
+		})
+	}
+	return s.upload(ctx, b, chatID, text, keyboard)
+}
+
+// upload is called with photoMu held so the first requests upload only once.
+func (s *Service) upload(ctx context.Context, b *bot.Bot, chatID int64, text string, keyboard models.ReplyMarkup) (*models.Message, error) {
+	if len(s.data) == 0 {
+		return nil, errors.New("cached menu photo was rejected; restore the source file and restart the bot")
+	}
+	message, err := b.SendPhoto(ctx, &bot.SendPhotoParams{
+		ChatID: chatID, Photo: &models.InputFileUpload{Filename: filepath.Base(s.path), Data: bytes.NewReader(s.data)},
+		Caption: text, ParseMode: models.ParseModeHTML, ReplyMarkup: keyboard,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(message.Photo) > 0 {
+		s.fileID = message.Photo[len(message.Photo)-1].FileID
+		s.photoDirty = true
+		s.persistPhoto(ctx)
+	}
+	return message, nil
+}
+
+// persistPhoto is called with photoMu held. Failed writes retry on the next send.
+func (s *Service) persistPhoto(ctx context.Context) {
+	if err := s.store.SavePhoto(ctx, s.botID, s.path, PhotoRecord{Hash: s.digest, FileID: s.fileID}); err != nil {
+		slog.Error("Failed to persist menu photo cache", "error", err)
+		return
+	}
+	s.photoDirty = false
+}
+
+func invalidFileID(err error) bool {
+	if !errors.Is(err, bot.ErrorBadRequest) {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "wrong file identifier") || strings.Contains(text, "wrong remote file identifier") ||
+		strings.Contains(text, "file_id_invalid") || strings.Contains(text, "file reference expired") ||
+		strings.Contains(text, "file_reference_expired")
+}
+
+func (s *Service) SendStart(ctx context.Context, b *bot.Bot, chatID int64, text string, keyboard models.ReplyMarkup) (*models.Message, error) {
+	lock := &s.chatLocks[uint64(chatID)%uint64(len(s.chatLocks))]
+	lock.Lock()
+	defer lock.Unlock()
+	message, err := s.Send(ctx, b, chatID, text, keyboard)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.replacePin(ctx, b, chatID, message.ID); err != nil {
+		// Lack of pin permissions must not prevent using the delivered menu.
+		slog.Warn("Failed to update pinned start menu", "error", err)
+	}
+	return message, nil
+}
+
+func (s *Service) replacePin(ctx context.Context, b *bot.Bot, chatID int64, messageID int) error {
+	oldPins, err := s.store.ListPins(ctx, s.botID, chatID)
+	if err != nil {
+		return err
+	}
+	// Persist intent before the API call, so even a crash/timeout cannot leave
+	// an untracked bot pin. Failed unpins remain tracked for the next /start.
+	if err := s.store.TrackPin(ctx, s.botID, chatID, messageID); err != nil {
+		return err
+	}
+	if _, err := b.PinChatMessage(ctx, &bot.PinChatMessageParams{
+		ChatID: chatID, MessageID: messageID, DisableNotification: true,
+	}); err != nil {
+		return err
+	}
+	var cleanupErrors []error
+	for _, oldID := range oldPins {
+		if oldID == messageID || oldID == 0 {
+			continue
+		}
+		_, err := b.UnpinChatMessage(ctx, &bot.UnpinChatMessageParams{ChatID: chatID, MessageID: oldID})
+		if err != nil && !missingPin(err) {
+			cleanupErrors = append(cleanupErrors, err)
+			continue
+		}
+		if err := s.store.ForgetPin(ctx, s.botID, chatID, oldID); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
+	}
+	return errors.Join(cleanupErrors...)
+}
+
+func missingPin(err error) bool {
+	if !errors.Is(err, bot.ErrorBadRequest) {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "message to unpin not found") || strings.Contains(text, "message is not pinned") ||
+		strings.Contains(text, "message_id_invalid")
+}
+
+// Edit preserves the existing photo and message ID (including its pin).
+// Older text-only menus continue to work after enabling or disabling photos.
+func Edit(ctx context.Context, b *bot.Bot, message *models.Message, params *bot.EditMessageTextParams) (*models.Message, error) {
+	if message == nil {
+		return nil, errors.New("menu message is inaccessible")
+	}
+	var result *models.Message
+	var err error
+	if len(message.Photo) > 0 {
+		result, err = b.EditMessageCaption(ctx, &bot.EditMessageCaptionParams{
+			ChatID: message.Chat.ID, MessageID: message.ID, Caption: params.Text,
+			ParseMode: params.ParseMode, CaptionEntities: params.Entities, ReplyMarkup: params.ReplyMarkup,
+		})
+	} else {
+		result, err = b.EditMessageText(ctx, params)
+	}
+	if errors.Is(err, bot.ErrorBadRequest) && strings.Contains(strings.ToLower(err.Error()), "message is not modified") {
+		return message, nil
+	}
+	return result, err
+}

--- a/internal/menu/menu.go
+++ b/internal/menu/menu.go
@@ -198,6 +198,14 @@ func (s *Service) replacePin(ctx context.Context, b *bot.Bot, chatID int64, mess
 	if _, err := b.PinChatMessage(ctx, &bot.PinChatMessageParams{
 		ChatID: chatID, MessageID: messageID, DisableNotification: true,
 	}); err != nil {
+		// A confirmed permission denial cannot have created a pin. Do not
+		// accumulate cleanup work while the bot lacks rights; uncertain
+		// errors (timeouts, server errors, rate limits) must remain tracked.
+		if pinPermissionDenied(err) {
+			if cleanupErr := s.store.ForgetPin(ctx, s.botID, chatID, messageID); cleanupErr != nil {
+				slog.Warn("Failed to forget denied menu pin", "error", cleanupErr)
+			}
+		}
 		return err
 	}
 	var cleanupErrors []error
@@ -215,6 +223,18 @@ func (s *Service) replacePin(ctx context.Context, b *bot.Bot, chatID int64, mess
 		}
 	}
 	return errors.Join(cleanupErrors...)
+}
+
+func pinPermissionDenied(err error) bool {
+	if errors.Is(err, bot.ErrorForbidden) {
+		return true
+	}
+	if !errors.Is(err, bot.ErrorBadRequest) {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "not enough rights") || strings.Contains(text, "chat_admin_required") ||
+		strings.Contains(text, "need administrator rights")
 }
 
 func missingPin(err error) bool {

--- a/internal/menu/menu_test.go
+++ b/internal/menu/menu_test.go
@@ -1,0 +1,476 @@
+package menu
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+)
+
+type memoryStore struct {
+	mu      sync.Mutex
+	photos  map[string]PhotoRecord
+	pins    map[string]map[int]bool
+	failure string
+}
+
+func newStore() *memoryStore {
+	return &memoryStore{photos: map[string]PhotoRecord{}, pins: map[string]map[int]bool{}}
+}
+
+func (s *memoryStore) LoadPhoto(_ context.Context, botID int64, path string) (PhotoRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failure == "load" {
+		return PhotoRecord{}, errors.New("load failed")
+	}
+	return s.photos[fmt.Sprint(botID)+":"+path], nil
+}
+func (s *memoryStore) SavePhoto(_ context.Context, botID int64, path string, record PhotoRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failure == "save" {
+		return errors.New("save failed")
+	}
+	s.photos[fmt.Sprint(botID)+":"+path] = record
+	return nil
+}
+func (s *memoryStore) ListPins(_ context.Context, botID, chatID int64) ([]int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failure == "list" {
+		return nil, errors.New("list failed")
+	}
+	var pins []int
+	for id := range s.pins[fmt.Sprintf("%d:%d", botID, chatID)] {
+		pins = append(pins, id)
+	}
+	sort.Ints(pins)
+	return pins, nil
+}
+func (s *memoryStore) TrackPin(_ context.Context, botID, chatID int64, messageID int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failure == "track" {
+		return errors.New("track failed")
+	}
+	key := fmt.Sprintf("%d:%d", botID, chatID)
+	if s.pins[key] == nil {
+		s.pins[key] = map[int]bool{}
+	}
+	s.pins[key][messageID] = true
+	return nil
+}
+func (s *memoryStore) ForgetPin(_ context.Context, botID, chatID int64, messageID int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failure == "forget" {
+		return errors.New("forget failed")
+	}
+	delete(s.pins[fmt.Sprintf("%d:%d", botID, chatID)], messageID)
+	return nil
+}
+
+type apiCall struct {
+	method string
+	values url.Values
+	upload bool
+}
+type fakeTelegram struct {
+	mu     sync.Mutex
+	calls  []apiCall
+	fail   func(apiCall) (int, string)
+	nextID int
+}
+
+func newTelegram(t *testing.T) (*bot.Bot, *fakeTelegram) {
+	t.Helper()
+	api := &fakeTelegram{nextID: 100}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(12 << 20); err != nil {
+			t.Error(err)
+			w.WriteHeader(500)
+			return
+		}
+		defer r.MultipartForm.RemoveAll()
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		call := apiCall{method: filepath.Base(r.URL.Path), values: r.Form, upload: len(r.MultipartForm.File) > 0}
+		api.calls = append(api.calls, call)
+		w.Header().Set("Content-Type", "application/json")
+		if api.fail != nil {
+			if code, description := api.fail(call); code != 0 {
+				w.WriteHeader(code)
+				_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error_code": code, "description": description})
+				return
+			}
+		}
+		var result any = true
+		if strings.HasPrefix(call.method, "send") || strings.HasPrefix(call.method, "edit") {
+			id, _ := strconv.Atoi(call.values.Get("message_id"))
+			if id == 0 {
+				api.nextID++
+				id = api.nextID
+			}
+			chatID, _ := strconv.ParseInt(call.values.Get("chat_id"), 10, 64)
+			msg := models.Message{ID: id, Chat: models.Chat{ID: chatID}}
+			if call.method == "sendPhoto" {
+				msg.Photo = []models.PhotoSize{{FileID: "small"}, {FileID: "cached-photo"}}
+			}
+			result = msg
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "result": result})
+	}))
+	t.Cleanup(server.Close)
+	b, err := bot.New("123:test", bot.WithSkipGetMe(), bot.WithServerURL(server.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b, api
+}
+
+func photoFile(t *testing.T, path string, value uint8) string {
+	t.Helper()
+	if path == "" {
+		path = filepath.Join(t.TempDir(), "menu.png")
+	}
+	img := image.NewRGBA(image.Rect(0, 0, 20, 20))
+	img.Set(0, 0, color.RGBA{R: value, A: 255})
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := png.Encode(f, img); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+func newService(t *testing.T, store Store, botID int64, path string) *Service {
+	t.Helper()
+	s, err := New(context.Background(), store, botID, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+func send(t *testing.T, s *Service, b *bot.Bot) {
+	t.Helper()
+	if _, err := s.Send(context.Background(), b, 42, "<b>Menu</b>", models.InlineKeyboardMarkup{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPhotoCacheReuseRestartReplacementAndBotIsolation(t *testing.T) {
+	b, api := newTelegram(t)
+	store := newStore()
+	path := photoFile(t, "", 1)
+	s := newService(t, store, 123, path)
+	send(t, s, b)
+	send(t, s, b)
+	send(t, newService(t, store, 123, path), b)
+	send(t, newService(t, store, 456, path), b)
+	photoFile(t, path, 2)
+	send(t, newService(t, store, 123, path), b)
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	send(t, newService(t, store, 123, path), b)
+	wantUploads := []bool{true, false, false, true, true, false}
+	for i, call := range api.calls {
+		if call.method != "sendPhoto" || call.upload != wantUploads[i] {
+			t.Fatalf("call %d: %+v", i, call)
+		}
+		if !call.upload && call.values.Get("photo") != "cached-photo" {
+			t.Fatalf("file_id was not reused: %+v", call)
+		}
+		if call.values.Get("caption") != "<b>Menu</b>" || call.values.Get("parse_mode") != "HTML" || call.values.Get("reply_markup") == "" {
+			t.Fatalf("lost caption/keyboard: %+v", call)
+		}
+	}
+}
+
+func TestPhotoValidation(t *testing.T) {
+	store := newStore()
+	path := filepath.Join(t.TempDir(), "photo.png")
+	if _, err := New(context.Background(), store, 1, path); err == nil {
+		t.Fatal("missing file accepted")
+	}
+	if err := os.WriteFile(path, []byte("invalid"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(context.Background(), store, 1, path); err == nil {
+		t.Fatal("invalid image accepted")
+	}
+	if err := os.WriteFile(path, make([]byte, 10*1024*1024+1), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(context.Background(), store, 1, path); err == nil {
+		t.Fatal("oversized image accepted")
+	}
+	store.failure = "load"
+	if _, err := New(context.Background(), store, 1, path); err == nil {
+		t.Fatal("cache load failure ignored")
+	}
+}
+
+func TestRejectedFileIDReuploadsButOtherErrorsDoNot(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		code        int
+		retries     bool
+	}{
+		{"Bad Request: wrong file identifier/HTTP URL specified", 400, true},
+		{"Bad Request: FILE_REFERENCE_EXPIRED", 400, true},
+		{"Bad Request: message caption is too long", 400, false},
+		{"Bad Request: can't parse entities", 400, false},
+		{"Forbidden: bot was blocked by the user", 403, false},
+		{"Internal Server Error", 500, false},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			b, api := newTelegram(t)
+			s := newService(t, newStore(), 123, photoFile(t, "", 1))
+			send(t, s, b)
+			api.fail = func(c apiCall) (int, string) {
+				if !c.upload {
+					return tc.code, tc.description
+				}
+				return 0, ""
+			}
+			_, err := s.Send(context.Background(), b, 42, "Menu", nil)
+			if (err == nil) != tc.retries {
+				t.Fatalf("unexpected result: %v", err)
+			}
+			want := 2
+			if tc.retries {
+				want = 3
+			}
+			if len(api.calls) != want {
+				t.Fatalf("got %d API calls, want %d", len(api.calls), want)
+			}
+		})
+	}
+}
+
+func TestPhotoCacheWriteRetriesWithoutUploadingAgain(t *testing.T) {
+	b, api := newTelegram(t)
+	store := newStore()
+	s := newService(t, store, 123, photoFile(t, "", 1))
+	store.failure = "save"
+	send(t, s, b)
+	store.failure = ""
+	send(t, s, b)
+	record, err := store.LoadPhoto(context.Background(), 123, s.path)
+	if err != nil || record.FileID != "cached-photo" || api.calls[1].upload {
+		t.Fatalf("cache retry failed: %+v %v", record, err)
+	}
+}
+
+func TestConcurrentPhotoRequestsUploadOnce(t *testing.T) {
+	b, api := newTelegram(t)
+	s := newService(t, newStore(), 123, photoFile(t, "", 1))
+	var wg sync.WaitGroup
+	for range 12 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := s.Send(context.Background(), b, 42, "Menu", nil); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+	uploads := 0
+	for _, call := range api.calls {
+		if call.upload {
+			uploads++
+		}
+	}
+	if uploads != 1 || len(api.calls) != 12 {
+		t.Fatalf("uploads=%d calls=%d", uploads, len(api.calls))
+	}
+}
+
+func TestStartReplacesOnlyTrackedPinsAcrossRestart(t *testing.T) {
+	for _, photo := range []bool{false, true} {
+		t.Run(fmt.Sprint(photo), func(t *testing.T) {
+			b, api := newTelegram(t)
+			store := newStore()
+			path := ""
+			if photo {
+				path = photoFile(t, "", 1)
+			}
+			ctx := context.Background()
+			first, err := newService(t, store, 123, path).SendStart(ctx, b, 42, "Menu", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// A different bot/chat must never be unpinned.
+			_ = store.TrackPin(ctx, 456, 42, 9)
+			_ = store.TrackPin(ctx, 123, 43, 10)
+			second, err := newService(t, store, 123, path).SendStart(ctx, b, 42, "Menu", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			method := "sendMessage"
+			if photo {
+				method = "sendPhoto"
+			}
+			want := []string{method, "pinChatMessage", method, "pinChatMessage", "unpinChatMessage"}
+			for i, call := range api.calls {
+				if call.method != want[i] {
+					t.Fatalf("call %d: %+v", i, call)
+				}
+				if call.method == "pinChatMessage" && call.values.Get("disable_notification") != "true" {
+					t.Fatal("noisy pin")
+				}
+			}
+			if api.calls[4].values.Get("message_id") != strconv.Itoa(first.ID) {
+				t.Fatal("wrong pin removed")
+			}
+			pins, _ := store.ListPins(ctx, 123, 42)
+			if !reflect.DeepEqual(pins, []int{second.ID}) {
+				t.Fatalf("pins: %v", pins)
+			}
+		})
+	}
+}
+
+func TestPinAndPersistenceFailuresKeepOldMenuTracked(t *testing.T) {
+	for _, failure := range []string{"send", "pin", "list", "track", "unpin", "forget", "deleted"} {
+		t.Run(failure, func(t *testing.T) {
+			ctx := context.Background()
+			b, api := newTelegram(t)
+			store := newStore()
+			_ = store.TrackPin(ctx, 123, 42, 50)
+			s := newService(t, store, 123, "")
+			store.failure = failure
+			api.fail = func(c apiCall) (int, string) {
+				if failure == "send" && c.method == "sendMessage" {
+					return 500, "unavailable"
+				}
+				if failure == "pin" && c.method == "pinChatMessage" {
+					return 400, "not enough rights"
+				}
+				if failure == "unpin" && c.method == "unpinChatMessage" {
+					return 500, "unavailable"
+				}
+				if failure == "deleted" && c.method == "unpinChatMessage" {
+					return 400, "Bad Request: message to unpin not found"
+				}
+				return 0, ""
+			}
+			_, err := s.SendStart(ctx, b, 42, "Menu", nil)
+			if (err != nil) != (failure == "send") {
+				t.Fatalf("menu delivery error: %v", err)
+			}
+			if failure == "pin" || failure == "list" || failure == "track" || failure == "send" {
+				for _, call := range api.calls {
+					if call.method == "unpinChatMessage" {
+						t.Fatal("old pin removed before new pin succeeds")
+					}
+				}
+			}
+			store.failure = ""
+			pins, _ := store.ListPins(ctx, 123, 42)
+			containsOld := false
+			for _, id := range pins {
+				if id == 50 {
+					containsOld = true
+				}
+			}
+			if containsOld != (failure != "deleted") {
+				t.Fatalf("lost cleanup state: %v", pins)
+			}
+			api.fail = nil
+			message, err := newService(t, store, 123, "").SendStart(ctx, b, 42, "Menu", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pins, _ = store.ListPins(ctx, 123, 42)
+			if !reflect.DeepEqual(pins, []int{message.ID}) {
+				t.Fatalf("cleanup not retried: %v", pins)
+			}
+		})
+	}
+}
+
+func TestConcurrentStartsLeaveOnePin(t *testing.T) {
+	b, api := newTelegram(t)
+	store := newStore()
+	s := newService(t, store, 123, "")
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := s.SendStart(context.Background(), b, 42, "Menu", nil); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+	pins, _ := store.ListPins(context.Background(), 123, 42)
+	if !reflect.DeepEqual(pins, []int{api.nextID}) {
+		t.Fatalf("pins: %v", pins)
+	}
+}
+
+func TestEditPreservesPhotoAndLegacyTextMenus(t *testing.T) {
+	for _, photo := range []bool{false, true} {
+		for _, description := range []string{"", "Bad Request: message is not modified", "Bad Request: message caption is too long"} {
+			t.Run(fmt.Sprintf("%t/%s", photo, description), func(t *testing.T) {
+				b, api := newTelegram(t)
+				message := &models.Message{ID: 50, Chat: models.Chat{ID: 42}}
+				if photo {
+					message.Photo = []models.PhotoSize{{FileID: "keep-me"}}
+				}
+				if description != "" {
+					api.fail = func(apiCall) (int, string) { return 400, description }
+				}
+				markup := models.InlineKeyboardMarkup{InlineKeyboard: [][]models.InlineKeyboardButton{{{Text: "Back", CallbackData: "start", Style: "primary", IconCustomEmojiID: "1234"}}}}
+				_, err := Edit(context.Background(), b, message, &bot.EditMessageTextParams{ChatID: 42, MessageID: 50, Text: "<b>Section</b>", ParseMode: models.ParseModeHTML, ReplyMarkup: markup})
+				if (err != nil) != strings.Contains(description, "too long") {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(api.calls) != 1 {
+					t.Fatal("edit sent/deleted another message")
+				}
+				call := api.calls[0]
+				method, field := "editMessageText", "text"
+				if photo {
+					method, field = "editMessageCaption", "caption"
+				}
+				if call.method != method || call.values.Get(field) != "<b>Section</b>" || call.values.Get("message_id") != "50" {
+					t.Fatalf("bad edit: %+v", call)
+				}
+				var got models.InlineKeyboardMarkup
+				if err := json.Unmarshal([]byte(call.values.Get("reply_markup")), &got); err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(got, markup) {
+					t.Fatal("lost inline keyboard styling")
+				}
+			})
+		}
+	}
+}

--- a/internal/menu/pin_permission_test.go
+++ b/internal/menu/pin_permission_test.go
@@ -1,0 +1,95 @@
+package menu
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/go-telegram/bot"
+)
+
+func TestPinDenialForgetsOnlyConfirmedFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		code   int
+		body   string
+		forget bool
+	}{
+		{"forbidden", 403, "Forbidden: bot is not a member of the chat", true},
+		{"rights", 400, "Bad Request: not enough rights to pin a message", true},
+		{"admin", 400, "Bad Request: CHAT_ADMIN_REQUIRED", true},
+		{"other_bad_request", 400, "Bad Request: unknown failure", false},
+		{"server_error", 500, "Internal Server Error", false},
+		{"rate_limit", 429, "Too Many Requests", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			b, api := newTelegram(t)
+			api.fail = func(apiCall) (int, string) { return tc.code, tc.body }
+			store := newStore()
+			_ = store.TrackPin(ctx, 123, 42, 50)
+			s := newService(t, store, 123, "")
+			if err := s.replacePin(ctx, b, 42, 100); err == nil {
+				t.Fatal("pin error lost")
+			}
+			pins, err := store.ListPins(ctx, 123, 42)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := []int{50, 100}
+			if tc.forget {
+				want = []int{50}
+			}
+			if !reflect.DeepEqual(pins, want) {
+				t.Fatalf("pins=%v want=%v", pins, want)
+			}
+			if len(api.calls) != 1 || api.calls[0].method != "pinChatMessage" {
+				t.Fatal("failed pin removed old menu")
+			}
+		})
+	}
+}
+
+func TestRepeatedPinDenialsDoNotAccumulateRows(t *testing.T) {
+	ctx := context.Background()
+	b, api := newTelegram(t)
+	api.fail = func(apiCall) (int, string) { return 403, "Forbidden" }
+	store := newStore()
+	_ = store.TrackPin(ctx, 123, 42, 50)
+	s := newService(t, store, 123, "")
+	for id := 100; id < 110; id++ {
+		if err := s.replacePin(ctx, b, 42, id); !errors.Is(err, bot.ErrorForbidden) {
+			t.Fatalf("original pin error lost: %v", err)
+		}
+	}
+	pins, _ := store.ListPins(ctx, 123, 42)
+	if !reflect.DeepEqual(pins, []int{50}) {
+		t.Fatalf("uncreated pins retained: %v", pins)
+	}
+}
+
+func TestPinDenialCleanupFailureKeepsRecoveryStateAndOriginalError(t *testing.T) {
+	ctx := context.Background()
+	b, api := newTelegram(t)
+	api.fail = func(apiCall) (int, string) { return 403, "Forbidden" }
+	store := newStore()
+	store.failure = "forget"
+	s := newService(t, store, 123, "")
+	if err := s.replacePin(ctx, b, 42, 100); !errors.Is(err, bot.ErrorForbidden) {
+		t.Fatalf("original error lost: %v", err)
+	}
+	pins, _ := store.ListPins(ctx, 123, 42)
+	if !reflect.DeepEqual(pins, []int{100}) {
+		t.Fatalf("recovery state lost: %v", pins)
+	}
+}
+
+func TestUncertainPinErrorsAreNeverClassifiedAsPermissionDenials(t *testing.T) {
+	for _, err := range []error{nil, context.Canceled, context.DeadlineExceeded, fmt.Errorf("request timed out: %w", context.DeadlineExceeded), errors.New("not enough rights")} {
+		if pinPermissionDenied(err) {
+			t.Fatalf("uncertain error classified as permission denial: %v", err)
+		}
+	}
+}

--- a/internal/payment/menu.go
+++ b/internal/payment/menu.go
@@ -1,0 +1,26 @@
+package payment
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"remnawave-tg-shop-bot/internal/database"
+)
+
+// Keep the navigation message, its photo and pin after payment. Only replace
+// the payment buttons; this works for both photo and legacy text menus.
+func (s PaymentService) refreshPurchaseMenu(ctx context.Context, purchaseID int64, customer *database.Customer) {
+	messageID, ok := s.cache.Get(purchaseID)
+	if !ok {
+		return
+	}
+	_, err := s.telegramBot.EditMessageReplyMarkup(ctx, &bot.EditMessageReplyMarkupParams{
+		ChatID: customer.TelegramID, MessageID: messageID,
+		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: s.createConnectKeyboard(customer)},
+	})
+	if err != nil {
+		slog.Warn("Failed to update menu after payment", "error", err)
+	}
+}

--- a/internal/payment/menu_test.go
+++ b/internal/payment/menu_test.go
@@ -1,0 +1,59 @@
+package payment
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"remnawave-tg-shop-bot/internal/cache"
+	"remnawave-tg-shop-bot/internal/database"
+	"remnawave-tg-shop-bot/internal/translation"
+)
+
+func TestPaymentKeepsMenuMessageAndPhoto(t *testing.T) {
+	requests := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Error(err)
+			return
+		}
+		defer r.MultipartForm.RemoveAll()
+		requests <- r.URL.Path
+		if r.FormValue("message_id") != "99" || r.FormValue("chat_id") != "42" {
+			t.Error("wrong menu edited")
+		}
+		var markup models.InlineKeyboardMarkup
+		if err := json.Unmarshal([]byte(r.FormValue("reply_markup")), &markup); err != nil {
+			t.Error(err)
+		}
+		if len(markup.InlineKeyboard) != 2 || markup.InlineKeyboard[1][0].CallbackData != "start" {
+			t.Error("lost menu navigation")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "result": models.Message{ID: 99}})
+	}))
+	defer server.Close()
+	b, err := bot.New("123:test", bot.WithSkipGetMe(), bot.WithServerURL(server.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := cache.NewCache(time.Minute)
+	c.Set(1, 99)
+	s := PaymentService{telegramBot: b, cache: c, translation: translation.GetInstance()}
+	s.refreshPurchaseMenu(context.Background(), 1, &database.Customer{TelegramID: 42, Language: "en"})
+	if path := <-requests; !strings.HasSuffix(path, "/editMessageReplyMarkup") {
+		t.Fatalf("menu was not preserved: %s", path)
+	}
+	s.refreshPurchaseMenu(context.Background(), 2, &database.Customer{TelegramID: 42})
+	select {
+	case path := <-requests:
+		t.Fatalf("uncached purchase touched menu: %s", path)
+	default:
+	}
+}

--- a/internal/payment/payment.go
+++ b/internal/payment/payment.go
@@ -80,16 +80,6 @@ func (s PaymentService) ProcessPurchaseById(ctx context.Context, purchaseId int6
 		return fmt.Errorf("customer %s not found", utils.MaskHalfInt64(purchase.CustomerID))
 	}
 
-	if messageId, b := s.cache.Get(purchase.ID); b {
-		_, err = s.telegramBot.DeleteMessage(ctx, &bot.DeleteMessageParams{
-			ChatID:    customer.TelegramID,
-			MessageID: messageId,
-		})
-		if err != nil {
-			slog.Error("Error deleting message", "error", err)
-		}
-	}
-
 	user, err := s.remnawaveClient.CreateOrUpdateUser(ctx, customer.ID, customer.TelegramID, config.TrafficLimit(), purchase.Month*config.DaysInMonth(), false)
 	if err != nil {
 		return err
@@ -109,6 +99,8 @@ func (s PaymentService) ProcessPurchaseById(ctx context.Context, purchaseId int6
 	if err != nil {
 		return err
 	}
+
+	s.refreshPurchaseMenu(ctx, purchase.ID, customer)
 
 	_, err = s.telegramBot.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID: customer.TelegramID,

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,50 @@ Telegram bot for selling and managing [Remnawave](https://remna.st/) subscriptio
 - Healthcheck endpoint for monitoring the bot, database, and Remnawave availability.
 - Docker-based deployment.
 
+## Menu photo and pinned start message
+
+The bot can show the same photo on the start menu and all its inline-keyboard sections.
+Put your own JPEG or PNG in `assets/menu.jpg` and set this in `.env`:
+
+```dotenv
+MENU_PHOTO_PATH=/assets/menu.jpg
+```
+
+The supplied `docker-compose.yaml` mounts `./assets:/assets:ro`. With an existing
+Compose file, add that mount to the bot service. The file must be readable by the
+container's UID 1000. For a non-Docker installation, use a local path such as
+`MENU_PHOTO_PATH=./assets/menu.jpg`. Leave the value empty for text-only menus.
+
+- Restart/recreate the bot after configuring or replacing the image. The first
+  menu delivery uploads it to Telegram; subsequent deliveries reuse its `file_id`.
+- The file ID, content hash and bot ID are stored in PostgreSQL, not in a
+  short-lived memory cache. An unchanged image is reused after restart. A changed
+  file is uploaded again on its next use; another bot has its own cache.
+- Keep the original file and the database volume. While running, the bot retains
+  the source in memory and can re-upload it if Telegram rejects the cached ID.
+  After restart, a missing source can still use the persisted ID, but cannot be
+  re-uploaded until the source is restored and the bot restarted. An invalid or
+  missing uncached source causes an explicit startup error rather than silently
+  disabling the photo.
+- Telegram photo limits: JPEG/PNG up to 10 MB; width + height at most 10000 pixels;
+  aspect ratio at most 20. **All menu captions, including customized translations
+  and connection details, must fit Telegram's 1024-character limit after HTML
+  parsing.** Text-only menus retain the ordinary text-message limits. Captions
+  are not silently truncated.
+- Inline navigation edits the caption and keyboard of the same photo message;
+  the image and pin remain in place. Payment completion no longer deletes the
+  menu. Existing text-only messages remain navigable; use `/start` for a new photo
+  menu. `/connect` also uses the configured photo, but does not replace the start pin.
+- Every `/start`, with or without a photo, sends and silently pins a new menu,
+  then unpins only previously tracked start menus from this bot in that chat.
+  Unrelated/manual pins are untouched. Pin state survives restart, and failed
+  unpins are retried on the next `/start`. If sending or pinning the new menu fails,
+  the old pin is not removed. Missing pin permissions do not block menu delivery
+  and are logged (groups require the appropriate bot administrator rights).
+
+Database migration `000006_add_menu_state` is applied automatically on startup.
+The pin replacement lock assumes one running polling instance per bot token.
+
 ## Links
 
 - [Documentation](https://docs.rwp.rw/ru/)


### PR DESCRIPTION
## Summary
- Add an optional local JPEG/PNG (MENU_PHOTO_PATH) to /start, /connect and inline menu navigation.
- Persist Telegram file_id and content hash, scoped to bot and source path; reuse after restarts and retry rejected IDs from the original source.
- Edit captions and keyboards in place; preserve photos, message IDs, pins and legacy text-only menus.
- Pin each new /start silently before unpinning tracked older bot menus; persist cleanup intent and retry failures after restart.
- Preserve navigation messages after payment instead of deleting them.
- Document deployment and limits; prepare version 5.1.0.

## Validation
- go test -race ./...: passed
- go vet ./...: passed
- go test -race -count=5 ./internal/menu ./internal/handler ./internal/payment: passed
- git diff --check: passed
- Tests cover cache reuse/restart/replacement/bot isolation, rejected file IDs, persistence failures, concurrency, pin lifecycle, photo/text edits and payment menu preservation.
- Telegram tests use a local mock. Live Telegram and PostgreSQL migration smoke tests are not yet run.

## Deployment
- Migration 000006_add_menu_state creates two new tables automatically on startup.
- Mount ./assets:/assets:ro and set MENU_PHOTO_PATH=/assets/menu.jpg; empty keeps text-only menus.
- Keep the source image and DB volume; restart after changing the image.
- Telegram caption limit: 1024 characters after HTML parsing. One polling instance per token.

## Release plan
Wait for review and investigate all actionable findings before merging. After merge, publish 5.1.0 and verify multi-platform container images tagged 5.1.0, 5 and latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional menu photos for the start screen and inline sections.
  - Added automatic photo caching and reuse across restarts.
  - Added pinned start-menu message management with cleanup and retry handling.
  - Added support for mounting local menu images in Docker deployments.

- **Bug Fixes**
  - Preserved photo captions and navigation during menu updates.
  - Payment completion now keeps the existing menu and its pin while refreshing available actions.

- **Documentation**
  - Added configuration, deployment, image requirements, and behavior details for menu photos and pinned messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->